### PR TITLE
Fix for possible NPE when checking for environent variables.

### DIFF
--- a/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
+++ b/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
@@ -355,23 +355,24 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
     }
 
     private String extractEnvironmentVariables(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener, String variable) {
-        EnvVars envVars = new EnvVars();
         PrintStream logger = listener.getLogger();
         String result = variable;
-        try {
-            envVars = run.getEnvironment(listener);
-            if (variable.startsWith("$")) {
-                if (variable.startsWith("${")) {
-                    result = envVars.get("$" + variable.substring(2, variable.length() - 1));
+        if (variable != null) {
+            try {
+                EnvVars envVars = run.getEnvironment( listener );
+                if (variable.startsWith( "$" )) {
+                    if (variable.startsWith( "${" )) {
+                        result = envVars.get( "$" + variable.substring( 2, variable.length() - 1 ) );
+                    }
+                    result = envVars.get( variable );
                 }
-                result = envVars.get(variable);
+                if (result == null) {
+                    logger.println( "Environment variable \"" + variable + "\" was not found" );
+                    run.setResult( Result.ABORTED );
+                }
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
             }
-            if (result == null) {
-                logger.println("Environment variable \"" + variable + "\" was not found");
-                run.setResult(Result.ABORTED);
-            }
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
         }
         return result;
     }

--- a/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
+++ b/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
@@ -355,7 +355,7 @@ public class WhiteSourcePipelineStep extends Step {
     }
 
     private static class Execution extends SynchronousNonBlockingStepExecution<Void> {
-
+        private static final long serialVersionUID = 1L;
         /* --- Members --- */
 
         private transient final WhiteSourcePipelineStep step;


### PR DESCRIPTION
While running Jenkins job got the NPE.  Not 100% sure which key it was.  Maybe API token.  Also made findbugs happy.

10:01:31 ERROR: Build step failed with exception
10:01:31 java.lang.NullPointerException
10:01:31 	at org.whitesource.jenkins.WhiteSourcePublisher.extractEnvironmentVariables(WhiteSourcePublisher.java:363)
10:01:31 	at org.whitesource.jenkins.WhiteSourcePublisher.checkEnvironmentVariables(WhiteSourcePublisher.java:351)
10:01:31 	at org.whitesource.jenkins.WhiteSourcePublisher.perform(WhiteSourcePublisher.java:122)
10:01:31 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
10:01:31 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
10:01:31 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:735)
10:01:31 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:676)
10:01:31 	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.post2(MavenModuleSetBuild.java:1072)
10:01:31 	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:621)
10:01:31 	at hudson.model.Run.execute(Run.java:1760)
10:01:31 	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:542)
10:01:31 	at hudson.model.ResourceController.execute(ResourceController.java:97)
10:01:31 	at hudson.model.Executor.run(Executor.java:405)
10:01:31 Build step 'White Source Publisher' marked build as failure
10:01:31 Finished: FAILURE