### PR TITLE
Hashing overflow when scanning for dependencies

### DIFF
--- a/src/main/java/org/whitesource/jenkins/extractor/generic/LibFolderScanner.java
+++ b/src/main/java/org/whitesource/jenkins/extractor/generic/LibFolderScanner.java
@@ -30,6 +30,7 @@ import org.whitesource.jenkins.model.RemoteDependency;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.util.*;
 
 /**
@@ -137,6 +138,8 @@ public class LibFolderScanner extends MasterToSlaveFileCallable<Collection<Remot
 					superHash.append(superHashResult.getFullHash());
 				}
 			} catch (IOException err) {
+				listener.getLogger().println("Error calculating fullHash for {}, Error - " + file.getName() + err.getMessage());
+			} catch (IllegalArgumentException err) {
 				listener.getLogger().println("Error calculating fullHash for {}, Error - " + file.getName() + err.getMessage());
 			}
 		}


### PR DESCRIPTION
This happened when the WhiteSource publisher plugin was scanning a job for dependencies. The overflow in calculating superHash failed the entire build and I would very much like this to not be the case. Without knowing the internals of WhiteSource's hashing functions, best I think we can do is catch illegal arguments and move on with our lives.

Alternatively, wrap the entire plugin such that the plugin failing doesn't impact the build as a whole?

Stack trace:
```
2018-06-15 01:53:36 Updating White Source.
2018-06-15 01:53:36 Collecting OSS usage information
2018-06-15 01:53:36 Starting generic job on /home/jenkins/workspace/foo
2018-06-15 01:53:37 Scanning folder foo
2018-06-15 01:54:36 ERROR: Build step failed with exception
2018-06-15 01:54:36 Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to ci-slave-stable (i-0f849437f5cea44e8)
2018-06-15 01:54:36 		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1737)
2018-06-15 01:54:36 		at hudson.remoting.UserResponse.retrieve(UserRequest.java:313)
2018-06-15 01:54:36 		at hudson.remoting.Channel.call(Channel.java:952)
2018-06-15 01:54:36 		at hudson.FilePath.act(FilePath.java:1009)
2018-06-15 01:54:36 		at hudson.FilePath.act(FilePath.java:998)
2018-06-15 01:54:36 		at org.whitesource.jenkins.extractor.generic.GenericOssInfoExtractor.extract(GenericOssInfoExtractor.java:82)
2018-06-15 01:54:36 		at org.whitesource.jenkins.model.WhiteSourceStep.getGenericProjectInfos(WhiteSourceStep.java:200)
2018-06-15 01:54:36 		at org.whitesource.jenkins.model.WhiteSourceStep.getProjectInfos(WhiteSourceStep.java:177)
2018-06-15 01:54:36 		at org.whitesource.jenkins.WhiteSourcePublisher.perform(WhiteSourcePublisher.java:148)
2018-06-15 01:54:36 		at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
2018-06-15 01:54:36 		at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
2018-06-15 01:54:36 		at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
2018-06-15 01:54:36 		at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
2018-06-15 01:54:36 		at hudson.model.Build$BuildExecution.post2(Build.java:186)
2018-06-15 01:54:36 		at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
2018-06-15 01:54:36 		at hudson.model.Run.execute(Run.java:1752)
2018-06-15 01:54:36 		at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
2018-06-15 01:54:36 		at hudson.model.ResourceController.execute(ResourceController.java:97)
2018-06-15 01:54:36 		at hudson.model.Executor.run(Executor.java:429)
2018-06-15 01:54:36 java.lang.IllegalArgumentException: Size cannot be greater than Integer max value: 2746511360
2018-06-15 01:54:36 	at org.apache.commons.io.IOUtils.toByteArray(IOUtils.java:485)
2018-06-15 01:54:36 	at org.apache.commons.io.FileUtils.readFileToByteArray(FileUtils.java:1764)
2018-06-15 01:54:36 	at org.whitesource.agent.hash.HashCalculator.calculateSuperHash(HashCalculator.java:91)
2018-06-15 01:54:36 	at org.whitesource.jenkins.extractor.generic.LibFolderScanner.calculateHashes(LibFolderScanner.java:132)
2018-06-15 01:54:36 	at org.whitesource.jenkins.extractor.generic.LibFolderScanner.collectDependencyInfo(LibFolderScanner.java:104)
2018-06-15 01:54:36 	at org.whitesource.jenkins.extractor.generic.LibFolderScanner.invoke(LibFolderScanner.java:85)
2018-06-15 01:54:36 	at org.whitesource.jenkins.extractor.generic.LibFolderScanner.invoke(LibFolderScanner.java:40)
2018-06-15 01:54:36 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2827)
2018-06-15 01:54:36 	at hudson.remoting.UserRequest.perform(UserRequest.java:210)
2018-06-15 01:54:36 	at hudson.remoting.UserRequest.perform(UserRequest.java:53)
2018-06-15 01:54:36 	at hudson.remoting.Request$2.run(Request.java:364)
2018-06-15 01:54:36 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
2018-06-15 01:54:36 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
2018-06-15 01:54:36 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2018-06-15 01:54:36 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2018-06-15 01:54:36 	at java.lang.Thread.run(Thread.java:748)
2018-06-15 01:54:36 Build step 'White Source Publisher' marked build as failure
```

For reference, here was the libIncludes used during the scan. A bit excessive, but it's autogenerated and better safe than sorry!

```
$JENKINS_HOME/.m2/**/*.aar,gradle/**/*.aar,foo/**/*.aar,$JENKINS_HOME/.m2/**/*.c,gradle/**/*.c,foo/**/*.c,$JENKINS_HOME/.m2/**/*.c#,gradle/**/*.c#,foo/**/*.c#,$JENKINS_HOME/.m2/**/*.c++,gradle/**/*.c++,foo/**/*.c++,$JENKINS_HOME/.m2/**/*.cc,gradle/**/*.cc,foo/**/*.cc,$JENKINS_HOME/.m2/**/*.cp,gradle/**/*.cp,foo/**/*.cp,$JENKINS_HOME/.m2/**/*.cpp,gradle/**/*.cpp,foo/**/*.cpp,$JENKINS_HOME/.m2/**/*.cs,gradle/**/*.cs,foo/**/*.cs,$JENKINS_HOME/.m2/**/*.csharp,gradle/**/*.csharp,foo/**/*.csharp,$JENKINS_HOME/.m2/**/*.cxx,gradle/**/*.cxx,foo/**/*.cxx,$JENKINS_HOME/.m2/**/*.deb,gradle/**/*.deb,foo/**/*.deb,$JENKINS_HOME/.m2/**/*.dll,gradle/**/*.dll,foo/**/*.dll,$JENKINS_HOME/.m2/**/*.ear,gradle/**/*.ear,foo/**/*.ear,$JENKINS_HOME/.m2/**/*.egg,gradle/**/*.egg,foo/**/*.egg,$JENKINS_HOME/.m2/**/*.egg,gradle/**/*.egg,foo/**/*.egg,$JENKINS_HOME/.m2/**/*.gem,gradle/**/*.gem,foo/**/*.gem,$JENKINS_HOME/.m2/**/*.gem,gradle/**/*.gem,foo/**/*.gem,$JENKINS_HOME/.m2/**/*.goc,gradle/**/*.goc,foo/**/*.goc,$JENKINS_HOME/.m2/**/*.gzip,gradle/**/*.gzip,foo/**/*.gzip,$JENKINS_HOME/.m2/**/*.h,gradle/**/*.h,foo/**/*.h,$JENKINS_HOME/.m2/**/*.hpp,gradle/**/*.hpp,foo/**/*.hpp,$JENKINS_HOME/.m2/**/*.hxx,gradle/**/*.hxx,foo/**/*.hxx,$JENKINS_HOME/.m2/**/*.jar,gradle/**/*.jar,foo/**/*.jar,$JENKINS_HOME/.m2/**/*.jar,gradle/**/*.jar,foo/**/*.jar,$JENKINS_HOME/.m2/**/*.java,gradle/**/*.java,foo/**/*.java,$JENKINS_HOME/.m2/**/*.js,gradle/**/*.js,foo/**/*.js,$JENKINS_HOME/.m2/**/*.m,gradle/**/*.m,foo/**/*.m,$JENKINS_HOME/.m2/**/*.mm,gradle/**/*.mm,foo/**/*.mm,$JENKINS_HOME/.m2/**/*.nupkg,gradle/**/*.nupkg,foo/**/*.nupkg,$JENKINS_HOME/.m2/**/*.php,gradle/**/*.php,foo/**/*.php,$JENKINS_HOME/.m2/**/*.py,gradle/**/*.py,foo/**/*.py,$JENKINS_HOME/.m2/**/*.rar,gradle/**/*.rar,foo/**/*.rar,$JENKINS_HOME/.m2/**/*.rb,gradle/**/*.rb,foo/**/*.rb,$JENKINS_HOME/.m2/**/*.rpm,gradle/**/*.rpm,foo/**/*.rpm,$JENKINS_HOME/.m2/**/*.sca,gradle/**/*.sca,foo/**/*.sca,$JENKINS_HOME/.m2/**/*.swc,gradle/**/*.swc,foo/**/*.swc,$JENKINS_HOME/.m2/**/*.swf,gradle/**/*.swf,foo/**/*.swf,$JENKINS_HOME/.m2/**/*.swift,gradle/**/*.swift,foo/**/*.swift,$JENKINS_HOME/.m2/**/*.tar,gradle/**/*.tar,foo/**/*.tar,$JENKINS_HOME/.m2/**/*.tar.bz2,gradle/**/*.tar.bz2,foo/**/*.tar.bz2,$JENKINS_HOME/.m2/**/*.tar.gz,gradle/**/*.tar.gz,foo/**/*.tar.gz,$JENKINS_HOME/.m2/**/*.tar.gz,gradle/**/*.tar.gz,foo/**/*.tar.gz,$JENKINS_HOME/.m2/**/*.tar.xz,gradle/**/*.tar.xz,foo/**/*.tar.xz,$JENKINS_HOME/.m2/**/*.tgz,gradle/**/*.tgz,foo/**/*.tgz,$JENKINS_HOME/.m2/**/*.tgz,gradle/**/*.tgz,foo/**/*.tgz,$JENKINS_HOME/.m2/**/*.war,gradle/**/*.war,foo/**/*.war,$JENKINS_HOME/.m2/**/*.whl,gradle/**/*.whl,foo/**/*.whl,$JENKINS_HOME/.m2/**/*.whl,gradle/**/*.whl,foo/**/*.whl,$JENKINS_HOME/.m2/**/*.zip,gradle/**/*.zip,foo/**/*.zip
```