### PR TITLE
Override Default For Project Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,14 +108,6 @@
             <!-- Add again after the fsa will be update -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.whitesource.analysis</groupId>
-                    <artifactId>whitesource-analysis-via</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.whitesource</groupId>
-                    <artifactId>wss-agent-via-api</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                 </exclusion>

--- a/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
+++ b/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
@@ -67,6 +67,8 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private String projectToken;
 
+    private String projectName;
+
     private String libIncludes;
 
     private String libExcludes;
@@ -93,6 +95,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
                                 String product,
                                 String productVersion,
                                 String projectToken,
+                                String projectName,
                                 String libIncludes,
                                 String libExcludes,
                                 String mavenProjectToken,
@@ -109,6 +112,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         this.product = product;
         this.productVersion = productVersion;
         this.projectToken = projectToken;
+        this.projectName = projectName;
         this.libIncludes = libIncludes;
         this.libExcludes = libExcludes;
         this.mavenProjectToken = mavenProjectToken;
@@ -393,6 +397,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         this.product = extractEnvironmentVariables(run, listener, this.product);
         this.productVersion = extractEnvironmentVariables(run, listener, this.productVersion);
         this.projectToken = extractEnvironmentVariables(run, listener, this.projectToken);
+        this.projectName = extractEnvironmentVariables(run, listener, this.projectName);
         this.libIncludes = extractEnvironmentVariables(run, listener, this.libIncludes);
         this.libExcludes = extractEnvironmentVariables(run, listener, this.libExcludes);
         this.requesterEmail = extractEnvironmentVariables(run, listener, this.requesterEmail);
@@ -449,6 +454,10 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     public String getProjectToken() {
         return projectToken;
+    }
+
+    public String getProjectName() {
+        return projectName;
     }
 
     public String getLibIncludes() {

--- a/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
+++ b/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -24,13 +25,14 @@ import java.util.List;
  */
 public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
 
-    public static final List<String> DEFAULT_SCAN_EXTENSIONS =  Arrays.asList("jar", "war", "ear", "par", "rar",
-            "dll", "exe", "ko", "so", "msi", "zip", "tar", "tar.gz", "swc", "swf");
-
+    public static final List<String> DEFAULT_SCAN_EXTENSIONS =  Collections.unmodifiableList(
+       Arrays.asList("jar", "war", "ear", "par", "rar", "dll", "exe", "ko", "so", "msi", "zip", "tar", "tar.gz", "swc", "swf")
+    );
 
     /* --- Members --- */
 
     private final String projectToken;
+    private final String projectName;
     private final FilePath workspace;
 
     /* --- Constructors --- */
@@ -39,9 +41,10 @@ public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
                                    String excludes,
                                    Run<?, ?> run,
                                    TaskListener listener,
-                                   String projectToken, FilePath workspace) {
+                                   String projectToken, String projectName, FilePath workspace) {
         super(includes, excludes, run, listener);
         this.projectToken = projectToken;
+        this.projectName = projectName;
         this.workspace = workspace;
     }
 
@@ -60,7 +63,8 @@ public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
         LibFolderScanner libScanner = new LibFolderScanner(includes, excludes, listener);
         AgentProjectInfo projectInfo = new AgentProjectInfo();
         if (StringUtils.isBlank(projectToken)) {
-            projectInfo.setCoordinates(new Coordinates(null, run.getParent().getName(), "build #" + run.getNumber()));
+            String projectName = StringUtils.isBlank(this.projectName) ? run.getParent().getName() : this.projectName;
+            projectInfo.setCoordinates(new Coordinates(null, projectName, "build #" + run.getNumber()));
         } else {
             projectInfo.setProjectToken(projectToken);
         }

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
@@ -62,6 +62,7 @@ public class WhiteSourceStep {
     private String product;
     private String productVersion;
     private String projectToken;
+    private String projectName;
     private String libIncludes;
     private String libExcludes;
     private String mavenProjectToken;
@@ -91,6 +92,7 @@ public class WhiteSourceStep {
         this.product = publisher.getProduct();
         this.productVersion = publisher.getProductVersion();
         this.projectToken = publisher.getProjectToken();
+        this.projectName = publisher.getProjectName();
         this.libIncludes = publisher.getLibIncludes();
         this.libExcludes = publisher.getLibExcludes();
         this.mavenProjectToken = publisher.getMavenProjectToken();
@@ -106,6 +108,7 @@ public class WhiteSourceStep {
         this.product = step.getProduct();
         this.productVersion = step.getProductVersion();
         this.projectToken = step.getProjectToken();
+        this.projectName = step.getProjectName();
         this.libIncludes = step.getLibIncludes();
         this.libExcludes = step.getLibExcludes();
         this.requesterEmail = step.getRequesterEmail();
@@ -204,7 +207,7 @@ public class WhiteSourceStep {
     private Collection<AgentProjectInfo> getGenericProjectInfos(Run<?, ?> run, TaskListener listener, FilePath workspace, PrintStream logger) throws InterruptedException, IOException {
         Collection<AgentProjectInfo> projectInfos;
         logger.println("Starting generic job on " + workspace.getRemote());
-        GenericOssInfoExtractor extractor = new GenericOssInfoExtractor(libIncludes, libExcludes, run, listener, projectToken, workspace);
+        GenericOssInfoExtractor extractor = new GenericOssInfoExtractor(libIncludes, libExcludes, run, listener, projectToken, projectName, workspace);
         projectInfos = extractor.extract();
         return projectInfos;
     }
@@ -454,6 +457,14 @@ public class WhiteSourceStep {
 
     public void setProjectToken(String projectToken) {
         this.projectToken = projectToken;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 
     public String getLibIncludes() {

--- a/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
+++ b/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
@@ -63,6 +63,8 @@ public class WhiteSourcePipelineStep extends Step {
 
     private String projectToken;
 
+    private String projectName;
+
     private String requesterEmail;
 
     private String libIncludes;
@@ -79,6 +81,7 @@ public class WhiteSourcePipelineStep extends Step {
                                    String product,
                                    String productVersion,
                                    String projectToken,
+                                   String projectName,
                                    String libIncludes,
                                    String libExcludes,
                                    String requesterEmail) {
@@ -90,6 +93,7 @@ public class WhiteSourcePipelineStep extends Step {
         this.product = product;
         this.productVersion = productVersion;
         this.projectToken = projectToken;
+        this.projectName = projectName;
         this.libIncludes = libIncludes;
         this.libExcludes = libExcludes;
         this.requesterEmail = requesterEmail;
@@ -161,6 +165,15 @@ public class WhiteSourcePipelineStep extends Step {
     @DataBoundSetter
     public void setProjectToken(String projectToken) {
         this.projectToken = projectToken;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @DataBoundSetter
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 
     public String getRequesterEmail() {

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
@@ -58,6 +58,9 @@
                         <f:entry title="Project token" field="projectToken" help="/plugin/whitesource/help/help-projectToken.html">
                             <f:textbox />
                         </f:entry>
+                        <f:entry title="Project token" field="projectName" help="/plugin/whitesource/help/help-projectName.html">
+                            <f:textbox />
+                        </f:entry>
                         <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">
                             <f:textbox />
                         </f:entry>

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
@@ -58,7 +58,7 @@
                         <f:entry title="Project token" field="projectToken" help="/plugin/whitesource/help/help-projectToken.html">
                             <f:textbox />
                         </f:entry>
-                        <f:entry title="Project token" field="projectName" help="/plugin/whitesource/help/help-projectName.html">
+                        <f:entry title="Project name" field="projectName" help="/plugin/whitesource/help/help-projectName.html">
                             <f:textbox />
                         </f:entry>
                         <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">

--- a/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
@@ -28,6 +28,9 @@
     <f:entry title="Project token" field="projectToken" help="/plugin/whitesource/help/help-projectToken.html">
         <f:textbox />
     </f:entry>
+    <f:entry title="Project Name" field="projectName" help="/plugin/whitesource/help/help-projectName.html">
+        <f:textbox />
+    </f:entry>
     <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">
         <f:textbox />
     </f:entry>

--- a/src/main/webapp/help/help-projectName.html
+++ b/src/main/webapp/help/help-projectName.html
@@ -1,0 +1,7 @@
+<div>
+	Name identifying the project to update.
+	<br/>
+	Useful for when you wish to have an organisational build, and do not have access to be able to issue tokens.
+	<br/>
+	Note that if projectToken is set, this name will be ignored
+</div>


### PR DESCRIPTION
Add the ability to override the projectName when no projectToken is defined, rather than using the name of the jenkins job.

This can be problematic when running an organisational build, since all of the builds are the name of the branch being built.