### PR TITLE
Wse 4859 credentials stored in plain text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,6 @@
                     <artifactId>whitesource-maven-plugin</artifactId>
                     <version>1.1.6</version>
                     <configuration>
-                        <!--suppress UnresolvedMavenProperty -->
                         <orgToken>${whitesource.orgToken}</orgToken>
                         <checkPolicies>true</checkPolicies>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>whitesource</artifactId>
-    <version>18.10.1-SNAPSHOT</version>
+    <version>20.8.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>White Source Jenkins plugin</name>
@@ -343,6 +343,7 @@
                     <artifactId>whitesource-maven-plugin</artifactId>
                     <version>1.1.6</version>
                     <configuration>
+                        <!--suppress UnresolvedMavenProperty -->
                         <orgToken>${whitesource.orgToken}</orgToken>
                         <checkPolicies>true</checkPolicies>
                     </configuration>

--- a/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
+++ b/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
@@ -56,7 +56,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private String jobForceUpdate;
 
-    private Secret jobApiToken;
+    private String jobApiToken;
 
     private String jobUserKey;
 
@@ -109,7 +109,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
     @DataBoundConstructor
     public WhiteSourcePublisher(String jobCheckPolicies,
                                 String jobForceUpdate,
-                                Secret jobApiToken,
+                                String jobApiToken,
                                 String jobUserKey,
                                 String product,
                                 String productVersion,
@@ -165,7 +165,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         WhiteSourceStep whiteSourceStep = new WhiteSourceStep(whiteSourcePublisher, new WhiteSourceDescriptor((DescriptorImpl) getDescriptor()));
 
         // make sure we have an organization token
-        if (StringUtils.isBlank(whiteSourceStep.getJobApiToken().getPlainText())) {
+        if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
             logger.println(Constants.INVALID_API_TOKEN);
             return;
         }
@@ -197,7 +197,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         private String serviceUrl;
 
-        private Secret apiToken;
+        private String apiToken;
 
         private String userKey;
 
@@ -215,7 +215,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         private String userName;
 
-        private String password;
+        private Secret password;
 
         private String connectionTimeout;
 
@@ -251,7 +251,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            apiToken = apiToken.fromString(json.getString(Constants.API_TOKEN));
+            apiToken = json.getString(Constants.API_TOKEN);
             userKey = json.getString(Constants.USER_KEY);
             serviceUrl = json.getString(Constants.SERVICE_URL);
             checkPolicies = json.getString(Constants.CHECK_POLICIES);
@@ -266,7 +266,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
                 server = proxySettings.getString(Constants.SERVER);
                 port = proxySettings.getString(Constants.PORT);
                 userName = proxySettings.getString(Constants.USER_NAME);
-                password = proxySettings.getString(Constants.PASSWORD);
+                password = password.fromString(proxySettings.getString(Constants.PASSWORD));
             }
             connectionTimeout = json.getString(Constants.CONNECTION_TIMEOUT);
             connectionRetries = json.getString(Constants.CONNECTION_RETRIES);
@@ -307,11 +307,11 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
             this.serviceUrl = serviceUrl;
         }
 
-        public Secret getApiToken() {
+        public String getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(Secret apiToken) {
+        public void setApiToken(String apiToken) {
             this.apiToken = apiToken;
         }
 
@@ -371,11 +371,11 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
             this.userName = userName;
         }
 
-        public String getPassword() {
+        public Secret getPassword() {
             return password;
         }
 
-        public void setPassword(String password) {
+        public void setPassword(Secret password) {
             this.password = password;
         }
 
@@ -417,7 +417,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private WhiteSourcePublisher checkEnvironmentVariables(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         WhiteSourcePublisher whiteSourcePublisher = new WhiteSourcePublisher(this);
-        whiteSourcePublisher.jobApiToken = this.jobApiToken.fromString(extractEnvironmentVariables(run, listener, this.jobApiToken.getPlainText()));
+        whiteSourcePublisher.jobApiToken = extractEnvironmentVariables(run, listener, this.jobApiToken);
         whiteSourcePublisher.jobUserKey = extractEnvironmentVariables(run, listener, this.jobUserKey);
         whiteSourcePublisher.product = extractEnvironmentVariables(run, listener, this.product);
         whiteSourcePublisher.productVersion = extractEnvironmentVariables(run, listener, this.productVersion);
@@ -470,7 +470,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return jobForceUpdate;
     }
 
-    public Secret getJobApiToken() {
+    public String getJobApiToken() {
         return jobApiToken;
     }
 

--- a/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
+++ b/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
@@ -25,6 +25,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -55,7 +56,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private String jobForceUpdate;
 
-    private String jobApiToken;
+    private Secret jobApiToken;
 
     private String jobUserKey;
 
@@ -108,7 +109,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
     @DataBoundConstructor
     public WhiteSourcePublisher(String jobCheckPolicies,
                                 String jobForceUpdate,
-                                String jobApiToken,
+                                Secret jobApiToken,
                                 String jobUserKey,
                                 String product,
                                 String productVersion,
@@ -164,7 +165,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         WhiteSourceStep whiteSourceStep = new WhiteSourceStep(whiteSourcePublisher, new WhiteSourceDescriptor((DescriptorImpl) getDescriptor()));
 
         // make sure we have an organization token
-        if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
+        if (StringUtils.isBlank(whiteSourceStep.getJobApiToken().getPlainText())) {
             logger.println(Constants.INVALID_API_TOKEN);
             return;
         }
@@ -196,7 +197,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         private String serviceUrl;
 
-        private String apiToken;
+        private Secret apiToken;
 
         private String userKey;
 
@@ -250,7 +251,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            apiToken = json.getString(Constants.API_TOKEN);
+            apiToken = apiToken.fromString(json.getString(Constants.API_TOKEN));
             userKey = json.getString(Constants.USER_KEY);
             serviceUrl = json.getString(Constants.SERVICE_URL);
             checkPolicies = json.getString(Constants.CHECK_POLICIES);
@@ -306,11 +307,11 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
             this.serviceUrl = serviceUrl;
         }
 
-        public String getApiToken() {
+        public Secret getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(String apiToken) {
+        public void setApiToken(Secret apiToken) {
             this.apiToken = apiToken;
         }
 
@@ -416,7 +417,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private WhiteSourcePublisher checkEnvironmentVariables(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         WhiteSourcePublisher whiteSourcePublisher = new WhiteSourcePublisher(this);
-        whiteSourcePublisher.jobApiToken = extractEnvironmentVariables(run, listener, this.jobApiToken);
+        whiteSourcePublisher.jobApiToken = this.jobApiToken.fromString(extractEnvironmentVariables(run, listener, this.jobApiToken.getPlainText()));
         whiteSourcePublisher.jobUserKey = extractEnvironmentVariables(run, listener, this.jobUserKey);
         whiteSourcePublisher.product = extractEnvironmentVariables(run, listener, this.product);
         whiteSourcePublisher.productVersion = extractEnvironmentVariables(run, listener, this.productVersion);
@@ -469,7 +470,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return jobForceUpdate;
     }
 
-    public String getJobApiToken() {
+    public Secret getJobApiToken() {
         return jobApiToken;
     }
 

--- a/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
+++ b/src/main/java/org/whitesource/jenkins/WhiteSourcePublisher.java
@@ -56,25 +56,25 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private String jobForceUpdate;
 
-    private String jobApiToken;
+    private Secret jobApiToken;
 
-    private String jobUserKey;
+    private Secret jobUserKey;
 
     private String product;
 
     private String productVersion;
 
-    private String projectToken;
+    private Secret projectToken;
 
     private String libIncludes;
 
     private String libExcludes;
 
-    private String mavenProjectToken;
+    private Secret mavenProjectToken;
 
     private String requesterEmail;
 
-    private String moduleTokens;
+    private Secret moduleTokens;
 
     private String modulesToInclude;
 
@@ -109,16 +109,16 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
     @DataBoundConstructor
     public WhiteSourcePublisher(String jobCheckPolicies,
                                 String jobForceUpdate,
-                                String jobApiToken,
-                                String jobUserKey,
+                                Secret jobApiToken,
+                                Secret jobUserKey,
                                 String product,
                                 String productVersion,
-                                String projectToken,
+                                Secret projectToken,
                                 String libIncludes,
                                 String libExcludes,
-                                String mavenProjectToken,
+                                Secret mavenProjectToken,
                                 String requesterEmail,
-                                String moduleTokens,
+                                Secret moduleTokens,
                                 String modulesToInclude,
                                 String modulesToExclude,
                                 boolean ignorePomModules) {
@@ -165,7 +165,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         WhiteSourceStep whiteSourceStep = new WhiteSourceStep(whiteSourcePublisher, new WhiteSourceDescriptor((DescriptorImpl) getDescriptor()));
 
         // make sure we have an organization token
-        if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
+        if (StringUtils.isBlank(Secret.toString(whiteSourceStep.getJobApiToken()))) {
             logger.println(Constants.INVALID_API_TOKEN);
             return;
         }
@@ -197,9 +197,9 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         private String serviceUrl;
 
-        private String apiToken;
+        private Secret apiToken;
 
-        private String userKey;
+        private Secret userKey;
 
         private String checkPolicies;
 
@@ -251,8 +251,8 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            apiToken = json.getString(Constants.API_TOKEN);
-            userKey = json.getString(Constants.USER_KEY);
+            apiToken = Secret.fromString(json.getString(Constants.API_TOKEN));
+            userKey = Secret.fromString(json.getString(Constants.USER_KEY));
             serviceUrl = json.getString(Constants.SERVICE_URL);
             checkPolicies = json.getString(Constants.CHECK_POLICIES);
             failOnError = json.getBoolean(Constants.FAIL_ON_ERROR);
@@ -266,7 +266,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
                 server = proxySettings.getString(Constants.SERVER);
                 port = proxySettings.getString(Constants.PORT);
                 userName = proxySettings.getString(Constants.USER_NAME);
-                password = password.fromString(proxySettings.getString(Constants.PASSWORD));
+                password = Secret.fromString(proxySettings.getString(Constants.PASSWORD));
             }
             connectionTimeout = json.getString(Constants.CONNECTION_TIMEOUT);
             connectionRetries = json.getString(Constants.CONNECTION_RETRIES);
@@ -307,19 +307,19 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
             this.serviceUrl = serviceUrl;
         }
 
-        public String getApiToken() {
+        public Secret getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(String apiToken) {
+        public void setApiToken(Secret apiToken) {
             this.apiToken = apiToken;
         }
 
-        public String getUserKey() {
+        public Secret getUserKey() {
             return userKey;
         }
 
-        public void setUserKey(String userKey) {
+        public void setUserKey(Secret userKey) {
             this.userKey = userKey;
         }
 
@@ -417,11 +417,11 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
 
     private WhiteSourcePublisher checkEnvironmentVariables(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         WhiteSourcePublisher whiteSourcePublisher = new WhiteSourcePublisher(this);
-        whiteSourcePublisher.jobApiToken = extractEnvironmentVariables(run, listener, this.jobApiToken);
-        whiteSourcePublisher.jobUserKey = extractEnvironmentVariables(run, listener, this.jobUserKey);
+        whiteSourcePublisher.jobApiToken = Secret.fromString(extractEnvironmentVariables(run, listener, Secret.toString(this.jobApiToken)));
+        whiteSourcePublisher.jobUserKey = Secret.fromString(extractEnvironmentVariables(run, listener, Secret.toString(this.jobUserKey)));
         whiteSourcePublisher.product = extractEnvironmentVariables(run, listener, this.product);
         whiteSourcePublisher.productVersion = extractEnvironmentVariables(run, listener, this.productVersion);
-        whiteSourcePublisher.projectToken = extractEnvironmentVariables(run, listener, this.projectToken);
+        whiteSourcePublisher.projectToken = Secret.fromString(extractEnvironmentVariables(run, listener, Secret.toString(this.projectToken)));
         whiteSourcePublisher.libIncludes = extractEnvironmentVariables(run, listener, this.libIncludes);
         whiteSourcePublisher.libExcludes = extractEnvironmentVariables(run, listener, this.libExcludes);
         whiteSourcePublisher.requesterEmail = extractEnvironmentVariables(run, listener, this.requesterEmail);
@@ -470,11 +470,11 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return jobForceUpdate;
     }
 
-    public String getJobApiToken() {
+    public Secret getJobApiToken() {
         return jobApiToken;
     }
 
-    public String getJobUserKey() {
+    public Secret getJobUserKey() {
         return jobUserKey;
     }
 
@@ -486,7 +486,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return productVersion;
     }
 
-    public String getProjectToken() {
+    public Secret getProjectToken() {
         return projectToken;
     }
 
@@ -498,7 +498,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return libExcludes;
     }
 
-    public String getMavenProjectToken() {
+    public Secret getMavenProjectToken() {
         return mavenProjectToken;
     }
 
@@ -506,7 +506,7 @@ public class WhiteSourcePublisher extends Publisher implements SimpleBuildStep {
         return requesterEmail;
     }
 
-    public String getModuleTokens() {
+    public Secret getModuleTokens() {
         return moduleTokens;
     }
 

--- a/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
+++ b/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
@@ -3,6 +3,7 @@ package org.whitesource.jenkins.extractor.generic;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;
 import org.whitesource.agent.api.model.AgentProjectInfo;
@@ -30,7 +31,7 @@ public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
 
     /* --- Members --- */
 
-    private final String projectToken;
+    private final Secret projectToken;
     private final FilePath workspace;
 
     /* --- Constructors --- */
@@ -39,7 +40,7 @@ public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
                                    String excludes,
                                    Run<?, ?> run,
                                    TaskListener listener,
-                                   String projectToken, FilePath workspace) {
+                                   Secret projectToken, FilePath workspace) {
         super(includes, excludes, run, listener);
         this.projectToken = projectToken;
         this.workspace = workspace;
@@ -59,10 +60,10 @@ public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
 
         LibFolderScanner libScanner = new LibFolderScanner(includes, excludes, listener);
         AgentProjectInfo projectInfo = new AgentProjectInfo();
-        if (StringUtils.isBlank(projectToken)) {
+        if (StringUtils.isBlank(Secret.toString(projectToken))) {
             projectInfo.setCoordinates(new Coordinates(null, run.getParent().getName(), "build #" + run.getNumber()));
         } else {
-            projectInfo.setProjectToken(projectToken);
+            projectInfo.setProjectToken(Secret.toString(projectToken));
         }
 
         if (workspace == null) {

--- a/src/main/java/org/whitesource/jenkins/extractor/maven/MavenOssInfoExtractor.java
+++ b/src/main/java/org/whitesource/jenkins/extractor/maven/MavenOssInfoExtractor.java
@@ -5,6 +5,7 @@ import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.maven.reporters.MavenArtifactRecord;
 import hudson.model.TaskListener;
+import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 import org.whitesource.agent.api.model.AgentProjectInfo;
 import org.whitesource.agent.api.model.Coordinates;
@@ -28,7 +29,7 @@ public class MavenOssInfoExtractor extends BaseOssInfoExtractor {
 
     private final MavenModuleSetBuild mavenModuleSetBuild;
 
-    private final String mavenProjectToken;
+    private final Secret mavenProjectToken;
 
     private final Map<String, String> moduleTokens;
 
@@ -40,15 +41,15 @@ public class MavenOssInfoExtractor extends BaseOssInfoExtractor {
                                  String excludes,
                                  MavenModuleSetBuild mavenModuleSetBuild,
                                  TaskListener listener,
-                                 String mavenProjectToken,
-                                 String moduleTokens,
+                                 Secret mavenProjectToken,
+                                 Secret moduleTokens,
                                  boolean ignorePomModules) {
         super(includes, excludes, mavenModuleSetBuild, listener);
 
         this.mavenModuleSetBuild = mavenModuleSetBuild;
         this.mavenProjectToken = mavenProjectToken;
         this.ignorePomModules = ignorePomModules;
-        this.moduleTokens = WssUtils.splitParametersMap(moduleTokens);
+        this.moduleTokens = WssUtils.splitParametersMap(Secret.toString(moduleTokens));
     }
 
     /* --- Concrete implementation methods --- */
@@ -75,7 +76,7 @@ public class MavenOssInfoExtractor extends BaseOssInfoExtractor {
                         action.pomArtifact.version));
 
                 if (moduleLastBuilds.size() == 1) {
-                    projectInfo.setProjectToken(mavenProjectToken);
+                    projectInfo.setProjectToken(Secret.toString(mavenProjectToken));
                 } else {
                     projectInfo.setProjectToken(moduleTokens.get(action.mainArtifact.artifactId));
                 }

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
@@ -1,5 +1,6 @@
 package org.whitesource.jenkins.model;
 
+import hudson.util.Secret;
 import org.whitesource.jenkins.WhiteSourcePublisher;
 import org.whitesource.jenkins.pipeline.WhiteSourcePipelineStep;
 
@@ -13,7 +14,7 @@ public class WhiteSourceDescriptor {
     /* --- Members --- */
 
     private String serviceUrl;
-    private String apiToken;
+    private Secret apiToken;
     private String userKey;
     private String checkPolicies;
     private boolean globalForceUpdate;
@@ -73,11 +74,11 @@ public class WhiteSourceDescriptor {
         this.serviceUrl = serviceUrl;
     }
 
-    public String getApiToken() {
+    public Secret getApiToken() {
         return apiToken;
     }
 
-    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
+    public void setApiToken(Secret apiToken) { this.apiToken = apiToken; }
 
     public String getUserKey() { return userKey; }
 

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
@@ -14,7 +14,7 @@ public class WhiteSourceDescriptor {
     /* --- Members --- */
 
     private String serviceUrl;
-    private Secret apiToken;
+    private String apiToken;
     private String userKey;
     private String checkPolicies;
     private boolean globalForceUpdate;
@@ -23,7 +23,7 @@ public class WhiteSourceDescriptor {
     private String server;
     private String port;
     private String userName;
-    private String password;
+    private Secret password;
     private String connectionTimeout;
     private String connectionRetries;
     private String connectionRetriesInterval;
@@ -74,11 +74,11 @@ public class WhiteSourceDescriptor {
         this.serviceUrl = serviceUrl;
     }
 
-    public Secret getApiToken() {
+    public String getApiToken() {
         return apiToken;
     }
 
-    public void setApiToken(Secret apiToken) { this.apiToken = apiToken; }
+    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
 
     public String getUserKey() { return userKey; }
 
@@ -140,11 +140,11 @@ public class WhiteSourceDescriptor {
         this.userName = userName;
     }
 
-    public String getPassword() {
+    public Secret getPassword() {
         return password;
     }
 
-    public void setPassword(String password) {
+    public void setPassword(Secret password) {
         this.password = password;
     }
 

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceDescriptor.java
@@ -14,8 +14,8 @@ public class WhiteSourceDescriptor {
     /* --- Members --- */
 
     private String serviceUrl;
-    private String apiToken;
-    private String userKey;
+    private Secret apiToken;
+    private Secret userKey;
     private String checkPolicies;
     private boolean globalForceUpdate;
     private boolean failOnError;
@@ -74,15 +74,15 @@ public class WhiteSourceDescriptor {
         this.serviceUrl = serviceUrl;
     }
 
-    public String getApiToken() {
+    public Secret getApiToken() {
         return apiToken;
     }
 
-    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
+    public void setApiToken(Secret apiToken) { this.apiToken = apiToken; }
 
-    public String getUserKey() { return userKey; }
+    public Secret getUserKey() { return userKey; }
 
-    public void setUserKey(String userKey) { this.userKey = userKey; }
+    public void setUserKey(Secret userKey) { this.userKey = userKey; }
 
     public String getCheckPolicies() {
         return checkPolicies;

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
@@ -61,16 +61,16 @@ public class WhiteSourceStep {
     /* --- Members --- */
     private WhiteSourceDescriptor globalConfig;
 
-    private String jobApiToken;
-    private String jobUserKey;
+    private Secret jobApiToken;
+    private Secret jobUserKey;
     private String product;
     private String productVersion;
-    private String projectToken;
+    private Secret projectToken;
     private String libIncludes;
     private String libExcludes;
-    private String mavenProjectToken;
+    private Secret mavenProjectToken;
     private String requesterEmail;
-    private String moduleTokens;
+    private Secret moduleTokens;
     private String modulesToInclude;
     private String modulesToExclude;
     private boolean ignorePomModules;
@@ -82,7 +82,8 @@ public class WhiteSourceStep {
 
     /* --- Constructor --- */
 
-    public WhiteSourceStep(WhiteSourceDescriptor globalConfig, String jobApiToken, String jobForceUpdate, String jobCheckPolicies, String jobUserKey) {
+    public WhiteSourceStep(WhiteSourceDescriptor globalConfig, Secret jobApiToken,
+                           String jobForceUpdate, String jobCheckPolicies, Secret jobUserKey) {
         this.globalConfig = globalConfig;
         setApiToken(jobApiToken);
         setUserKey(jobUserKey);
@@ -91,7 +92,8 @@ public class WhiteSourceStep {
     }
 
     public WhiteSourceStep(WhiteSourcePublisher publisher, WhiteSourceDescriptor globalConfig) {
-        this(globalConfig, publisher.getJobApiToken(), publisher.getJobForceUpdate(), publisher.getJobCheckPolicies(), publisher.getJobUserKey());
+        this(globalConfig, publisher.getJobApiToken(), publisher.getJobForceUpdate(),
+                publisher.getJobCheckPolicies(), publisher.getJobUserKey());
         this.product = publisher.getProduct();
         this.productVersion = publisher.getProductVersion();
         this.projectToken = publisher.getProjectToken();
@@ -124,10 +126,10 @@ public class WhiteSourceStep {
         try {
             if (shouldCheckPolicies) {
                 logger.println("Checking policies");
-                CheckPolicyComplianceRequest policyRequest = new CheckPolicyComplianceRequest(jobApiToken, projectInfos ,checkAllLibraries);
+                CheckPolicyComplianceRequest policyRequest = new CheckPolicyComplianceRequest(Secret.toString(jobApiToken), projectInfos ,checkAllLibraries);
                 policyRequest.setProduct(productNameOrToken);
                 policyRequest.setProductVersion(productVersion);
-                policyRequest.setUserKey(jobUserKey);
+                policyRequest.setUserKey(Secret.toString(jobUserKey));
                 CheckPolicyComplianceResult result= service.checkPolicyCompliance(policyRequest);
                 policyCheckReport(result, run, listener);
                 boolean hasRejections = result.hasRejections();
@@ -281,12 +283,12 @@ public class WhiteSourceStep {
         return service;
     }
 
-    private void sendUpdate(String orgToken,
+    private void sendUpdate(Secret orgToken,
                             String requesterEmail,
                             String productNameOrToken,
                             Collection<AgentProjectInfo> projectInfos,
                             WhitesourceService service,
-                            PrintStream logger, String productVersion, String userKey) throws WssServiceException {
+                            PrintStream logger, String productVersion, Secret userKey) throws WssServiceException {
         logger.println("Sending to White Source");
 
         int retries =  Integer.parseInt(globalConfig.getConnectionRetries());
@@ -296,7 +298,8 @@ public class WhiteSourceStep {
         UpdateInventoryResult updateResult = null;
         while (retries-- > -1) {
             try {
-                UpdateInventoryRequest updateRequest = new UpdateInventoryRequest(orgToken,productNameOrToken,productVersion,projectInfos,userKey,null);
+                UpdateInventoryRequest updateRequest = new UpdateInventoryRequest(Secret.toString(orgToken),
+                        productNameOrToken, productVersion, projectInfos, Secret.toString(userKey), null);
                 updateRequest.setRequesterEmail(requesterEmail);
                 updateResult = service.update(updateRequest);
                 if(updateResult != null) {
@@ -357,12 +360,12 @@ public class WhiteSourceStep {
         run.addAction(new PolicyCheckReportAction(run));
     }
 
-    private void setApiToken(String jobApiToken) {
-        this.jobApiToken = StringUtils.isNotBlank(jobApiToken) ? jobApiToken : globalConfig.getApiToken();
+    private void setApiToken(Secret jobApiToken) {
+        this.jobApiToken = StringUtils.isNotBlank(Secret.toString(jobApiToken)) ? jobApiToken : globalConfig.getApiToken();
     }
 
-    private void setUserKey(String jobUerKey) {
-        this.jobUserKey = StringUtils.isNotBlank(jobUerKey) ? jobUerKey : globalConfig.getUserKey();
+    private void setUserKey(Secret jobUserKey) {
+        this.jobUserKey = StringUtils.isNotBlank(Secret.toString(jobUserKey)) ? jobUserKey : globalConfig.getUserKey();
     }
 
     private void isCheckPolicies(String jobCheckPolicies) {
@@ -433,19 +436,19 @@ public class WhiteSourceStep {
         this.globalConfig = globalConfig;
     }
 
-    public String getJobApiToken() {
+    public Secret getJobApiToken() {
         return jobApiToken;
     }
 
-    public void setJobApiToken(String jobApiToken) {
+    public void setJobApiToken(Secret jobApiToken) {
         this.jobApiToken = jobApiToken;
     }
 
-    public String getJobUserKey() {
+    public Secret getJobUserKey() {
         return jobUserKey;
     }
 
-    public void setJobUserKey(String jobUserKey) {
+    public void setJobUserKey(Secret jobUserKey) {
         this.jobUserKey = jobUserKey;
     }
 
@@ -465,11 +468,11 @@ public class WhiteSourceStep {
         this.productVersion = productVersion;
     }
 
-    public String getProjectToken() {
+    public Secret getProjectToken() {
         return projectToken;
     }
 
-    public void setProjectToken(String projectToken) {
+    public void setProjectToken(Secret projectToken) {
         this.projectToken = projectToken;
     }
 
@@ -489,11 +492,11 @@ public class WhiteSourceStep {
         this.libExcludes = libExcludes;
     }
 
-    public String getMavenProjectToken() {
+    public Secret getMavenProjectToken() {
         return mavenProjectToken;
     }
 
-    public void setMavenProjectToken(String mavenProjectToken) {
+    public void setMavenProjectToken(Secret mavenProjectToken) {
         this.mavenProjectToken = mavenProjectToken;
     }
 
@@ -505,11 +508,11 @@ public class WhiteSourceStep {
         this.requesterEmail = requesterEmail;
     }
 
-    public String getModuleTokens() {
+    public Secret getModuleTokens() {
         return moduleTokens;
     }
 
-    public void setModuleTokens(String moduleTokens) {
+    public void setModuleTokens(Secret moduleTokens) {
         this.moduleTokens = moduleTokens;
     }
 
@@ -615,8 +618,8 @@ public class WhiteSourceStep {
             }
         }
         for (AgentProjectInfo agentProjectInfo : fsaProjects.keySet()) {
-            if (projectToken != null && (StringUtils.isNotBlank(projectToken))) {
-                agentProjectInfo.setProjectToken(projectToken); // WSE-494 fix
+            if (projectToken != null && (StringUtils.isNotBlank(Secret.toString(projectToken)))) {
+                agentProjectInfo.setProjectToken(Secret.toString(projectToken)); // WSE-494 fix
             } else {
                 if (agentProjectInfo.getCoordinates() != null) {
                     agentProjectInfo.setCoordinates(new Coordinates(null, agentProjectInfo.getCoordinates().getArtifactId(), productVersion));

--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
@@ -61,7 +61,7 @@ public class WhiteSourceStep {
     /* --- Members --- */
     private WhiteSourceDescriptor globalConfig;
 
-    private Secret jobApiToken;
+    private String jobApiToken;
     private String jobUserKey;
     private String product;
     private String productVersion;
@@ -82,7 +82,7 @@ public class WhiteSourceStep {
 
     /* --- Constructor --- */
 
-    public WhiteSourceStep(WhiteSourceDescriptor globalConfig, Secret jobApiToken, String jobForceUpdate, String jobCheckPolicies, String jobUserKey) {
+    public WhiteSourceStep(WhiteSourceDescriptor globalConfig, String jobApiToken, String jobForceUpdate, String jobCheckPolicies, String jobUserKey) {
         this.globalConfig = globalConfig;
         setApiToken(jobApiToken);
         setUserKey(jobUserKey);
@@ -124,7 +124,7 @@ public class WhiteSourceStep {
         try {
             if (shouldCheckPolicies) {
                 logger.println("Checking policies");
-                CheckPolicyComplianceRequest policyRequest = new CheckPolicyComplianceRequest(jobApiToken.getPlainText(), projectInfos ,checkAllLibraries);
+                CheckPolicyComplianceRequest policyRequest = new CheckPolicyComplianceRequest(jobApiToken, projectInfos ,checkAllLibraries);
                 policyRequest.setProduct(productNameOrToken);
                 policyRequest.setProductVersion(productVersion);
                 policyRequest.setUserKey(jobUserKey);
@@ -144,13 +144,13 @@ public class WhiteSourceStep {
                             " were force updated to organization inventory." :
                             "All dependencies conform with open source policies.";
                     logger.println(message);
-                    sendUpdate(jobApiToken.getPlainText(), requesterEmail, productNameOrToken, projectInfos, service, logger, productVersion, jobUserKey);
+                    sendUpdate(jobApiToken, requesterEmail, productNameOrToken, projectInfos, service, logger, productVersion, jobUserKey);
                     if (globalConfig.isFailOnError() && hasRejections) {
                         stopBuild(run, listener, "White Source Publisher failure");
                     }
                 }
             } else {
-                sendUpdate(jobApiToken.getPlainText(), requesterEmail, productNameOrToken, projectInfos, service, logger, productVersion, jobUserKey);
+                sendUpdate(jobApiToken, requesterEmail, productNameOrToken, projectInfos, service, logger, productVersion, jobUserKey);
             }
         } catch (WssServiceException | IOException | RuntimeException e) {
             stopBuildOnError(run, globalConfig.isFailOnError(), listener, e);
@@ -256,7 +256,7 @@ public class WhiteSourceStep {
                 host = globalConfig.getServer();
                 port = StringUtils.isBlank(globalConfig.getPort()) ? 0 : Integer.parseInt(globalConfig.getPort());
                 userName = globalConfig.getUserName();
-                password = globalConfig.getPassword();
+                password = Secret.toString(globalConfig.getPassword());
             } else { // proxy is configured in jenkins global settings
                 Hudson hudsonInstance = Hudson.getInstance();
                 if (hudsonInstance == null) {
@@ -357,8 +357,8 @@ public class WhiteSourceStep {
         run.addAction(new PolicyCheckReportAction(run));
     }
 
-    private void setApiToken(Secret jobApiToken) {
-        this.jobApiToken = StringUtils.isNotBlank(jobApiToken.getPlainText()) ? jobApiToken : globalConfig.getApiToken();
+    private void setApiToken(String jobApiToken) {
+        this.jobApiToken = StringUtils.isNotBlank(jobApiToken) ? jobApiToken : globalConfig.getApiToken();
     }
 
     private void setUserKey(String jobUerKey) {
@@ -433,11 +433,11 @@ public class WhiteSourceStep {
         this.globalConfig = globalConfig;
     }
 
-    public Secret getJobApiToken() {
+    public String getJobApiToken() {
         return jobApiToken;
     }
 
-    public void setJobApiToken(Secret jobApiToken) {
+    public void setJobApiToken(String jobApiToken) {
         this.jobApiToken = jobApiToken;
     }
 

--- a/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
+++ b/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
@@ -58,7 +58,7 @@ public class WhiteSourcePipelineStep extends Step {
 
     private String jobForceUpdate;
 
-    private Secret jobApiToken;
+    private String jobApiToken;
 
     private String jobUserKey;
 
@@ -75,7 +75,7 @@ public class WhiteSourcePipelineStep extends Step {
     @DataBoundConstructor
     public WhiteSourcePipelineStep(String jobCheckPolicies,
                                    String jobForceUpdate,
-                                   Secret jobApiToken,
+                                   String jobApiToken,
                                    String jobUserKey,
                                    String product,
                                    String productVersion,
@@ -141,12 +141,12 @@ public class WhiteSourcePipelineStep extends Step {
         this.jobForceUpdate = jobForceUpdate;
     }
 
-    public Secret getJobApiToken() {
+    public String getJobApiToken() {
         return jobApiToken;
     }
 
     @DataBoundSetter
-    public void setJobApiToken(Secret jobApiToken) {
+    public void setJobApiToken(String jobApiToken) {
         this.jobApiToken = jobApiToken;
     }
 
@@ -199,7 +199,7 @@ public class WhiteSourcePipelineStep extends Step {
         /* --- Members --- */
 
         private String serviceUrl;
-        private Secret apiToken;
+        private String apiToken;
         private String userKey;
         private String pipelineCheckPolicies;
         private boolean globalForceUpdate;
@@ -208,7 +208,7 @@ public class WhiteSourcePipelineStep extends Step {
         private String server;
         private String port;
         private String userName;
-        private String password;
+        private Secret password;
         private String connectionTimeout;
         private String connectionRetries;
         private String connectionRetriesInterval;
@@ -243,7 +243,7 @@ public class WhiteSourcePipelineStep extends Step {
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             serviceUrl = json.getString(Constants.SERVICE_URL);
-            apiToken = apiToken.fromString(json.getString(Constants.API_TOKEN));
+            apiToken = json.getString(Constants.API_TOKEN);
             userKey = json.getString(Constants.USER_KEY);
             pipelineCheckPolicies = json.getString(Constants.PIPELINE_CHECK_POLICIES);
             failOnError = json.getBoolean(Constants.FAIL_ON_ERROR);
@@ -255,7 +255,7 @@ public class WhiteSourcePipelineStep extends Step {
             } else {
                 overrideProxySettings = true;
                 userName = proxySettings.getString(Constants.USER_NAME);
-                password = proxySettings.getString(Constants.PASSWORD);
+                password = Secret.fromString(proxySettings.getString(Constants.PASSWORD));
                 server = proxySettings.getString(Constants.SERVER);
                 port = proxySettings.getString(Constants.PORT);
             }
@@ -299,11 +299,11 @@ public class WhiteSourcePipelineStep extends Step {
             this.serviceUrl = serviceUrl;
         }
 
-        public Secret getApiToken() {
+        public String getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(Secret apiToken) {
+        public void setApiToken(String apiToken) {
             this.apiToken = apiToken;
         }
 
@@ -359,11 +359,11 @@ public class WhiteSourcePipelineStep extends Step {
             this.userName = userName;
         }
 
-        public String getPassword() {
+        public Secret getPassword() {
             return password;
         }
 
-        public void setPassword(String password) {
+        public void setPassword(Secret password) {
             this.password = password;
         }
 
@@ -433,7 +433,7 @@ public class WhiteSourcePipelineStep extends Step {
             WhiteSourceStep whiteSourceStep = new WhiteSourceStep(step, new WhiteSourceDescriptor((DescriptorImpl) step.getDescriptor()));
 
             // make sure we have an organization token
-            if (StringUtils.isBlank(whiteSourceStep.getJobApiToken().getPlainText())) {
+            if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
                 logger.println(Constants.INVALID_API_TOKEN);
                 return null;
             }

--- a/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
+++ b/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
@@ -58,11 +58,11 @@ public class WhiteSourcePipelineStep extends Step {
 
     private String jobForceUpdate;
 
-    private String jobApiToken;
+    private Secret jobApiToken;
 
-    private String jobUserKey;
+    private Secret jobUserKey;
 
-    private String projectToken;
+    private Secret projectToken;
 
     private String requesterEmail;
 
@@ -75,11 +75,11 @@ public class WhiteSourcePipelineStep extends Step {
     @DataBoundConstructor
     public WhiteSourcePipelineStep(String jobCheckPolicies,
                                    String jobForceUpdate,
-                                   String jobApiToken,
-                                   String jobUserKey,
+                                   Secret jobApiToken,
+                                   Secret jobUserKey,
                                    String product,
                                    String productVersion,
-                                   String projectToken,
+                                   Secret projectToken,
                                    String libIncludes,
                                    String libExcludes,
                                    String requesterEmail) {
@@ -141,26 +141,26 @@ public class WhiteSourcePipelineStep extends Step {
         this.jobForceUpdate = jobForceUpdate;
     }
 
-    public String getJobApiToken() {
+    public Secret getJobApiToken() {
         return jobApiToken;
     }
 
     @DataBoundSetter
-    public void setJobApiToken(String jobApiToken) {
+    public void setJobApiToken(Secret jobApiToken) {
         this.jobApiToken = jobApiToken;
     }
 
-    public String getJobUserKey() { return jobUserKey; }
+    public Secret getJobUserKey() { return jobUserKey; }
 
     @DataBoundSetter
-    public void setJobUserKey(String jobUserKey) { this.jobUserKey = jobUserKey; }
+    public void setJobUserKey(Secret jobUserKey) { this.jobUserKey = jobUserKey; }
 
-    public String getProjectToken() {
+    public Secret getProjectToken() {
         return projectToken;
     }
 
     @DataBoundSetter
-    public void setProjectToken(String projectToken) {
+    public void setProjectToken(Secret projectToken) {
         this.projectToken = projectToken;
     }
 
@@ -199,8 +199,8 @@ public class WhiteSourcePipelineStep extends Step {
         /* --- Members --- */
 
         private String serviceUrl;
-        private String apiToken;
-        private String userKey;
+        private Secret apiToken;
+        private Secret userKey;
         private String pipelineCheckPolicies;
         private boolean globalForceUpdate;
         private boolean failOnError;
@@ -243,8 +243,8 @@ public class WhiteSourcePipelineStep extends Step {
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             serviceUrl = json.getString(Constants.SERVICE_URL);
-            apiToken = json.getString(Constants.API_TOKEN);
-            userKey = json.getString(Constants.USER_KEY);
+            apiToken = Secret.fromString(json.getString(Constants.API_TOKEN));
+            userKey = Secret.fromString(json.getString(Constants.USER_KEY));
             pipelineCheckPolicies = json.getString(Constants.PIPELINE_CHECK_POLICIES);
             failOnError = json.getBoolean(Constants.FAIL_ON_ERROR);
             globalForceUpdate = json.getBoolean(Constants.GLOBAL_FORCE_UPDATE);
@@ -299,17 +299,17 @@ public class WhiteSourcePipelineStep extends Step {
             this.serviceUrl = serviceUrl;
         }
 
-        public String getApiToken() {
+        public Secret getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(String apiToken) {
+        public void setApiToken(Secret apiToken) {
             this.apiToken = apiToken;
         }
 
-        public String getUserKey() { return userKey; }
+        public Secret getUserKey() { return userKey; }
 
-        public void setUserKey(String userKey) { this.userKey = userKey; }
+        public void setUserKey(Secret userKey) { this.userKey = userKey; }
 
         public String getCheckPolicies() {
             return pipelineCheckPolicies;
@@ -433,7 +433,7 @@ public class WhiteSourcePipelineStep extends Step {
             WhiteSourceStep whiteSourceStep = new WhiteSourceStep(step, new WhiteSourceDescriptor((DescriptorImpl) step.getDescriptor()));
 
             // make sure we have an organization token
-            if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
+            if (StringUtils.isBlank(Secret.toString(whiteSourceStep.getJobApiToken()))) {
                 logger.println(Constants.INVALID_API_TOKEN);
                 return null;
             }

--- a/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
+++ b/src/main/java/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep.java
@@ -21,6 +21,7 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
@@ -57,7 +58,7 @@ public class WhiteSourcePipelineStep extends Step {
 
     private String jobForceUpdate;
 
-    private String jobApiToken;
+    private Secret jobApiToken;
 
     private String jobUserKey;
 
@@ -74,7 +75,7 @@ public class WhiteSourcePipelineStep extends Step {
     @DataBoundConstructor
     public WhiteSourcePipelineStep(String jobCheckPolicies,
                                    String jobForceUpdate,
-                                   String jobApiToken,
+                                   Secret jobApiToken,
                                    String jobUserKey,
                                    String product,
                                    String productVersion,
@@ -140,12 +141,12 @@ public class WhiteSourcePipelineStep extends Step {
         this.jobForceUpdate = jobForceUpdate;
     }
 
-    public String getJobApiToken() {
+    public Secret getJobApiToken() {
         return jobApiToken;
     }
 
     @DataBoundSetter
-    public void setJobApiToken(String jobApiToken) {
+    public void setJobApiToken(Secret jobApiToken) {
         this.jobApiToken = jobApiToken;
     }
 
@@ -198,7 +199,7 @@ public class WhiteSourcePipelineStep extends Step {
         /* --- Members --- */
 
         private String serviceUrl;
-        private String apiToken;
+        private Secret apiToken;
         private String userKey;
         private String pipelineCheckPolicies;
         private boolean globalForceUpdate;
@@ -242,7 +243,7 @@ public class WhiteSourcePipelineStep extends Step {
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             serviceUrl = json.getString(Constants.SERVICE_URL);
-            apiToken = json.getString(Constants.API_TOKEN);
+            apiToken = apiToken.fromString(json.getString(Constants.API_TOKEN));
             userKey = json.getString(Constants.USER_KEY);
             pipelineCheckPolicies = json.getString(Constants.PIPELINE_CHECK_POLICIES);
             failOnError = json.getBoolean(Constants.FAIL_ON_ERROR);
@@ -298,11 +299,11 @@ public class WhiteSourcePipelineStep extends Step {
             this.serviceUrl = serviceUrl;
         }
 
-        public String getApiToken() {
+        public Secret getApiToken() {
             return apiToken;
         }
 
-        public void setApiToken(String apiToken) {
+        public void setApiToken(Secret apiToken) {
             this.apiToken = apiToken;
         }
 
@@ -432,7 +433,7 @@ public class WhiteSourcePipelineStep extends Step {
             WhiteSourceStep whiteSourceStep = new WhiteSourceStep(step, new WhiteSourceDescriptor((DescriptorImpl) step.getDescriptor()));
 
             // make sure we have an organization token
-            if (StringUtils.isBlank(whiteSourceStep.getJobApiToken())) {
+            if (StringUtils.isBlank(whiteSourceStep.getJobApiToken().getPlainText())) {
                 logger.println(Constants.INVALID_API_TOKEN);
                 return null;
             }

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
@@ -50,13 +50,13 @@
                             <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                         </f:entry>
                         <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                            <f:secretTextarea />
+                            <f:password />
                         </f:entry>
                         <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
-                            <f:textbox />
+                            <f:password />
                         </f:entry>
                         <f:entry title="Project token" field="projectToken" help="/plugin/whitesource/help/help-projectToken.html">
-                            <f:textbox />
+                            <f:password />
                         </f:entry>
                         <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">
                             <f:textbox />
@@ -88,20 +88,20 @@
                                                  <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                                         </f:entry>
                     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                        <f:secretTextarea />
+                        <f:password />
                     </f:entry>
                     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
-                        <f:textbox />
+                        <f:password />
                     </f:entry>
                     <f:advanced>
                         <f:entry title="Project token" field="mavenProjectToken" help="/plugin/whitesource/help/help-mavenProjectToken.html">
-                            <f:textbox />
+                            <f:password />
                         </f:entry>
                         <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">
                             <f:textbox />
                         </f:entry>
                         <f:entry title="Module tokens" field="moduleTokens" help="/plugin/whitesource/help/help-moduleTokens.html">
-                            <f:expandableTextbox />
+                            <f:password />
                         </f:entry>
                         <f:entry title="Modules to include" field="modulesToInclude" help="/plugin/whitesource/help/help-modulesToInclude.html">
                             <f:expandableTextbox />

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
@@ -50,7 +50,7 @@
                             <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                         </f:entry>
                         <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                            <f:textbox />
+                            <f:passward />
                         </f:entry>
                         <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
                             <f:textbox />
@@ -88,7 +88,7 @@
                                                  <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                                         </f:entry>
                     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                        <f:textbox />
+                        <f:passward />
                     </f:entry>
                     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
                         <f:textbox />

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/config.jelly
@@ -50,7 +50,7 @@
                             <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                         </f:entry>
                         <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                            <f:passward />
+                            <f:secretTextarea />
                         </f:entry>
                         <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
                             <f:textbox />
@@ -88,7 +88,7 @@
                                                  <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
                                         </f:entry>
                     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-                        <f:passward />
+                        <f:secretTextarea />
                     </f:entry>
                     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
                         <f:textbox />

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/global.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/global.jelly
@@ -8,7 +8,7 @@
       <f:section title="White Source Publisher">
         <f:entry title="API token" field="apiToken"
                 help="/plugin/whitesource/help/help-apiToken.html">
-        <f:textbox/>
+        <f:secretTextarea/>
         </f:entry>
          <f:entry title="User key" field="userKey"
                                         help="/plugin/whitesource/help/help-userKey.html">

--- a/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/global.jelly
+++ b/src/main/resources/org/whitesource/jenkins/WhiteSourcePublisher/global.jelly
@@ -8,11 +8,11 @@
       <f:section title="White Source Publisher">
         <f:entry title="API token" field="apiToken"
                 help="/plugin/whitesource/help/help-apiToken.html">
-        <f:secretTextarea/>
+            <f:password/>
         </f:entry>
          <f:entry title="User key" field="userKey"
                                         help="/plugin/whitesource/help/help-userKey.html">
-            <f:textbox/>
+            <f:password/>
         </f:entry>
         <f:entry title="Service url" field="serviceUrl"
                 help="/plugin/whitesource/help/help-serviceUrl.html">

--- a/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
@@ -20,13 +20,13 @@
         <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
     </f:entry>
     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-        <f:secretTextarea />
+        <f:password />
     </f:entry>
     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
-        <f:textbox />
+        <f:password />
     </f:entry>
     <f:entry title="Project token" field="projectToken" help="/plugin/whitesource/help/help-projectToken.html">
-        <f:textbox />
+        <f:password />
     </f:entry>
     <f:entry title="Requester email" field="requesterEmail" help="/plugin/whitesource/help/help-requesterEmail.html">
         <f:textbox />

--- a/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
@@ -20,7 +20,7 @@
         <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
     </f:entry>
     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-        <f:passward />
+        <f:secretTextarea />
     </f:entry>
     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
         <f:textbox />

--- a/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
+++ b/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/config.jelly
@@ -20,7 +20,7 @@
         <f:radio name="jobForceUpdate" title="Update" value="jobUpdate" checked="${selectedForceUpdate == 'jobUpdate'}"/>
     </f:entry>
     <f:entry title="Override API token" field="jobApiToken" help="/plugin/whitesource/help/help-jobApiToken.html">
-        <f:textbox />
+        <f:passward />
     </f:entry>
     <f:entry title="Override User Key" field="jobUserKey" help="/plugin/whitesource/help/help-jobUserKey.html">
         <f:textbox />

--- a/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/global.jelly
+++ b/src/main/resources/org/whitesource/jenkins/pipeline/WhiteSourcePipelineStep/global.jelly
@@ -8,11 +8,11 @@
       <f:section title="White Source Pipeline">
         <f:entry title="API token" field="apiToken"
                 help="/plugin/whitesource/help/help-apiToken.html">
-            <f:textbox/>
+            <f:password/>
         </f:entry>
         <f:entry title="User key" field="userKey"
                                 help="/plugin/whitesource/help/help-userKey.html">
-                <f:textbox/>
+                <f:password/>
         </f:entry>
         <f:entry title="Service url" field="serviceUrl"
                 help="/plugin/whitesource/help/help-serviceUrl.html">


### PR DESCRIPTION
This PR is for solving the security problem specified at: https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1630
"Credentials stored in plain text by White Source Plugin 
SECURITY-1630 / CVE-2020-2213
White Source Plugin 19.1.1 and earlier stores credentials in plain text as part of its global configuration file org.whitesource.jenkins.pipeline.WhiteSourcePipelineStep.xml and job config.xml files on the Jenkins controller. These credentials could be viewed by users with Extended Read permission (in the case of job config.xml files) or access to the Jenkins controller file system.

As of publication of this advisory, there is no fix."