### PR TITLE
Fix Jenkins plugin reporting the wrong version in WhiteSource console

### DIFF
--- a/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
+++ b/src/main/java/org/whitesource/jenkins/model/WhiteSourceStep.java
@@ -52,7 +52,7 @@ public class WhiteSourceStep {
 
     public static final String SPACE = " ";
     private static final String PLUGIN_AGENTS_VERSION = "2.9.5";
-    private static final String PLUGIN_VERSION = "19.1.1";
+    private static final String PLUGIN_VERSION = "20.10.1";
     public static final String WITH_MAVEN = "withMaven";
     public static final String GENERIC_GLOB_PATTERN = "**/*.";
     public static final String COMMA = ",";


### PR DESCRIPTION
Updates `WhiteSourceStep.java` to the same plugin version as specified in the `pom.xml` file.

This should probably be updated with the same automation that updates the `pom.xml` file with new version numbers, otherwise this issue will almost certainly reoccur.