### PR TITLE
updated parent dependencies to align with 4.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
     </properties>
 
     <dependencies>
-        
         <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-aggregator -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
     <properties>
         <!-- Minimal Jenkins version (2.14.0 ) required by for pipeline job -->
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <!--<jenkins.version>2.14</jenkins.version>-->
         <!--<jenkins.version>2.60.3</jenkins.version>-->
         <slf4j.version>1.7.30</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.8</version>
+        <version>4.27</version>
     </parent>
 
     <artifactId>whitesource</artifactId>
@@ -77,10 +77,10 @@
 
     <properties>
         <!-- Minimal Jenkins version (2.14.0 ) required by for pipeline job -->
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <!--<jenkins.version>2.14</jenkins.version>-->
         <!--<jenkins.version>2.60.3</jenkins.version>-->
-        <slf4j.version>1.7.5</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <java.level>8</java.level>
         <agent.version>2.9.5</agent.version>
         <skipTests>true</skipTests>
@@ -88,11 +88,11 @@
     </properties>
 
     <dependencies>
+        
         <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-aggregator -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-step-api -->
         <!--<dependency>-->
@@ -103,12 +103,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.75</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.0</version>
             <exclusions>
                 <!--<exclusion>-->
                     <!--<groupId>org.kohsuke</groupId>-->
@@ -124,17 +122,17 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.2.1</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.6</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -159,7 +157,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.52.Final</version>
+            <version>5.0.0.Alpha2</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>com.fasterxml.jackson.core</groupId>-->
@@ -174,7 +172,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -184,7 +182,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -288,12 +286,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.7</version>
+            <version>3.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -307,15 +304,15 @@
         </dependency>
         <dependency>
 
-            <groupId>org.jenkinsci.plugins</groupId>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>1.1.14</version>
+            <version>4.8.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4</version>
+            <version>4.4.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>
@@ -331,7 +328,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.9</version>
         </dependency>
 
         <!-- Logging -->
@@ -354,6 +350,148 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>966.v3857b7c82032</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>3.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>1.14.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20190722</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.connector-factory</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch.agentproxy.svnkit-trilead-ssh2</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>0.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>5.13.0.202109080827-r</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-builder-support</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model-builder</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>xpp3</groupId>
+                <artifactId>xpp3</artifactId>
+                <version>1.1.4c</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>5.0.0.Alpha2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.12.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.12.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.12.4</version>
+            </dependency>
+            </dependencies>
+    </dependencyManagement>
+
     <build>
         <resources>
             <resource>
@@ -365,7 +503,6 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.112</version>
                 <executions>
                     <execution>
                         <configuration>
@@ -400,16 +537,6 @@
                     <configuration>
                         <orgToken>${whitesource.orgToken}</orgToken>
                         <checkPolicies>true</checkPolicies>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
                     </configuration>
                 </plugin>
 
@@ -458,17 +585,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.3</version>
-                        <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
-                    </plugin>
-
 
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
             <version>1.60</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
             <version>4.5.13</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
+++ b/src/main/java/org/whitesource/jenkins/extractor/generic/GenericOssInfoExtractor.java
@@ -25,8 +25,8 @@ import java.util.List;
  */
 public class GenericOssInfoExtractor extends BaseOssInfoExtractor {
 
-    public static final List<String> DEFAULT_SCAN_EXTENSIONS =  Arrays.asList("jar", "war", "ear", "par", "rar",
-            "dll", "exe", "ko", "so", "msi", "zip", "tar", "tar.gz", "swc", "swf");
+    public static final List<String> DEFAULT_SCAN_EXTENSIONS =  java.util.Collections.unmodifiableList(Arrays.asList("jar", "war", "ear", "par", "rar",
+            "dll", "exe", "ko", "so", "msi", "zip", "tar", "tar.gz", "swc", "swf"));
 
 
     /* --- Members --- */


### PR DESCRIPTION
Fixed spotbug issue in collection

Updated dependencies with 4.27, and fixed a Findbug issue. Note that it might be interesting to think about updating https://github.com/whitesource/fs-agent as it is referencing old libraries and it forced a lot of dependency fixes in the Jenkins plugin
